### PR TITLE
完全一致ではなく前方一致でエントリを取得

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -43,15 +43,22 @@ def extract_url(request_uri):
     return None
 
 
+def get_entry(url):
+    for k, v in acl.items():
+        if url.startswith(k):
+            return v
+    return None
+
+
 def get_authorized_usernames(url):
     """Return list of usernames for given url."""
-    entry = acl.get(url)
+    entry = get_entry(url)
     return entry.get("users", []) if entry else []
 
 
 def get_authorized_group_dns(url):
     """Return list of group dns for given url."""
-    entry = acl.get(url)
+    entry = get_entry(url)
     return entry.get("groups", []) if entry else []
 
 


### PR DESCRIPTION
# 詳細

README.adocのACL config exampleの設定の場合、元の実装では、/app1/をチェックするが、/app1/hoge.htmlはチェックしていなかった。/app1/にアクセス許可がないユーザが、/app1/hoge.htmlにアクセスできていた。これは一般的に期待される挙動とは異なると考えられる。

これは文字列の完全一致でチェック対象を扱っていたためなので、前方一致で確認するように修正した。

# テスト内容

/app1/と/app1/hoge.htmlが同様に処理されることを実環境にて動作試験済み。

# チェックリスト

- [x] 自身でコードレビューを実施済みであること
- [ ] 特に理解が困難な箇所について、適切なコメントを記述してあること
- [ ] コードの静的検証を実行し、摘出したエラーを全て対処してあること
- [ ] 必要なドキュメント修正が完了してあること
- [x] 変更によって新たな警告が生じていないこと
