### PR TITLE
port毎に同じ名前のlocationを処理できるようにconfig.jsonの構造を変更（その２）

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ location /auth/ { # <1>
 <2> Specify that this location is used for internal subrequests only.
 <3> Add a header to pass the remote user's username to the proxy.
 <4> Add a header to pass the original request URI to the proxy.
-<5> Add a header to pass the request port to the proxy.
+<5> Add a header to pass the server port to the proxy.
 <6> Forward the request to an <<Usage, authentication server>> running on localhost at port 5000.
 
 Add location block for application.

--- a/README.adoc
+++ b/README.adoc
@@ -39,14 +39,16 @@ location /auth/ { # <1>
     internal; # <2>
     proxy_set_header X-Remote-User $remote_user; # <3>
     proxy_set_header X-Request-Uri $request-uri; # <4>
-    proxy_pass http://localhost:5000/auth/; # <5>
+    proxy_set_header X-Request-Port "443"; # <5>
+    proxy_pass http://localhost:5000/auth/; # <6>
 }
 ----
 <1> Define a location block for handling authentication requests.
 <2> Specify that this location is used for internal subrequests only.
 <3> Add a header to pass the remote user's username to the proxy.
 <4> Add a header to pass the original request URI to the proxy.
-<5> Forward the request to an <<Usage, authentication server>> running on localhost at port 5000.
+<5> Add a header to pass the request port to the proxy.
+<6> Forward the request to an <<Usage, authentication server>> running on localhost at port 5000.
 
 Add location block for application.
 
@@ -62,23 +64,32 @@ location /.../ {
 <3> Forward the request to an application server.
 
 === ACL
-Create a configuration file in JSON, and specify an array of usernames or the DN of groups allowed to access each URL, using the URLs as keys. For URLs not specified in this file, access will not be restricted (access is allowed if authenticated via SPNEGO).
+Create a configuration file in JSON, and specify an array of usernames or the DN of groups allowed to access each URL, using the ports and URLs as keys. For URLs not specified in this file, access will not be restricted (access is allowed if authenticated via SPNEGO).
 
 .ACL config example
 [,json]
 ----
 {
-  "/app1/": {
-    "users": [
-      "user1",
-      "user2"
-    ],
-    "groups": [
-      "CN=Managers,OU=Sales,DC=example,DC=com",
+  "443": {
+    "/app1/": {
+      "users": [
+        "user1",
+        "user2"
+      ],
+      "groups": [
+        "CN=Managers,OU=Sales,DC=example,DC=com",
+        ...
+      ]
+    },
+    "/app2/": {
       ...
-    ]
+    },
+    ...
   },
-  "/app2/": {
+  "80": {
+    "/app1/": {
+      ...
+    },
     ...
   },
   ...

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ location /auth/ { # <1>
     internal; # <2>
     proxy_set_header X-Remote-User $remote_user; # <3>
     proxy_set_header X-Request-Uri $request-uri; # <4>
-    proxy_set_header X-Request-Port "443"; # <5>
+    proxy_set_header X-Server-Port $server_port; # <5>
     proxy_pass http://localhost:5000/auth/; # <6>
 }
 ----

--- a/auth.py
+++ b/auth.py
@@ -49,6 +49,7 @@ def get_entry(url, port):
             return v
     return None
 
+
 def get_authorized_usernames(url, port):
     """Return list of usernames for given url."""
     entry = get_entry(url, port)
@@ -66,15 +67,15 @@ def auth():
     """Authenticate user based on ACL."""
     username = request.headers.get("X-Remote-User")
     request_uri = request.headers.get("X-Request-Uri")
-    request_port = request.headers.get("X-Request-Port")
+    server_port = request.headers.get("X-Server-Port")
     if not username or not request_uri:
         # Miscofigured nginx
         return make_response("Internal Server Error", 500)
 
     url = extract_url(request_uri)
 
-    authorized_usernames = get_authorized_usernames(url, request_port)
-    authorized_group_dns = get_authorized_group_dns(url, request_port)
+    authorized_usernames = get_authorized_usernames(url, server_port)
+    authorized_group_dns = get_authorized_group_dns(url, server_port)
 
     # No additional auth required
     if not authorized_usernames and not authorized_group_dns:

--- a/auth.py
+++ b/auth.py
@@ -43,22 +43,21 @@ def extract_url(request_uri):
     return None
 
 
-def get_entry(url):
-    for k, v in acl.items():
+def get_entry(url, port):
+    for k, v in acl[port].items():
         if url.startswith(k):
             return v
     return None
 
-
-def get_authorized_usernames(url):
+def get_authorized_usernames(url, port):
     """Return list of usernames for given url."""
-    entry = get_entry(url)
+    entry = get_entry(url, port)
     return entry.get("users", []) if entry else []
 
 
-def get_authorized_group_dns(url):
+def get_authorized_group_dns(url, port):
     """Return list of group dns for given url."""
-    entry = get_entry(url)
+    entry = get_entry(url, port)
     return entry.get("groups", []) if entry else []
 
 
@@ -67,14 +66,15 @@ def auth():
     """Authenticate user based on ACL."""
     username = request.headers.get("X-Remote-User")
     request_uri = request.headers.get("X-Request-Uri")
+    request_port = request.headers.get("X-Request-Port")
     if not username or not request_uri:
         # Miscofigured nginx
         return make_response("Internal Server Error", 500)
 
     url = extract_url(request_uri)
 
-    authorized_usernames = get_authorized_usernames(url)
-    authorized_group_dns = get_authorized_group_dns(url)
+    authorized_usernames = get_authorized_usernames(url, request_port)
+    authorized_group_dns = get_authorized_group_dns(url, request_port)
 
     # No additional auth required
     if not authorized_usernames and not authorized_group_dns:

--- a/auth.py
+++ b/auth.py
@@ -44,6 +44,8 @@ def extract_url(request_uri):
 
 
 def get_entry(url, port):
+    if port not in acl:
+        return None
     for k, v in acl[port].items():
         if url.startswith(k):
             return v


### PR DESCRIPTION
# 詳細

https://github.com/udzuki/spnego-nginx-auth-extension/pull/2

の続き。

指摘事項に対応して、作業ブランチからのPRを作り直した。

# テスト内容

port違い同じlocationにconfig.jsonの通り異なるACLが効くことを実環境にて動作試験済み。

# チェックリスト

- [x] 自身でコードレビューを実施済みであること
- [ ] 特に理解が困難な箇所について、適切なコメントを記述してあること
- [ ] コードの静的検証を実行し、摘出したエラーを全て対処してあること
- [x] 必要なドキュメント修正が完了してあること
- [x] 変更によって新たな警告が生じていないこと
