### PR TITLE
最長一致かつ前方一致でエントリを取得

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,6 +65,7 @@ location /.../ {
 
 === ACL
 Create a configuration file in JSON, and specify an array of usernames or the DN of groups allowed to access each URL, using the ports and URLs as keys. For URLs not specified in this file, access will not be restricted (access is allowed if authenticated via SPNEGO).
+Keys for URLs are matched based on a prefix match and longest match.
 
 .ACL config example
 [,json]
@@ -82,6 +83,9 @@ Create a configuration file in JSON, and specify an array of usernames or the DN
       ]
     },
     "/app2/": {
+      ...
+    },
+    "/app2/admin/": {
       ...
     },
     ...

--- a/auth.py
+++ b/auth.py
@@ -44,16 +44,15 @@ def extract_url(request_uri):
 
 
 def get_entry(url, port):
-    ret_entry = None
     if port not in acl:
-        return ret_entry
-    keylen = 0
+        return None
+    longest_match = None
+    max_length = 0
     for k, v in acl[port].items():
-        now_keylen = len(k)
-        if now_keylen > keylen and url.startswith(k):
-            keylen = now_keylen
-            ret_entry = v
-    return ret_entry
+        if url.startswith(k) and len(k) > max_length:
+            longest_match = v
+            max_length = len(k)
+    return longest_match
 
 
 def get_authorized_usernames(url, port):

--- a/auth.py
+++ b/auth.py
@@ -44,12 +44,16 @@ def extract_url(request_uri):
 
 
 def get_entry(url, port):
+    ret_entry = None
     if port not in acl:
-        return None
+        return ret_entry
+    keylen = 0
     for k, v in acl[port].items():
-        if url.startswith(k):
-            return v
-    return None
+        now_keylen = len(k)
+        if now_keylen > keylen and url.startswith(k):
+            keylen = now_keylen
+            ret_entry = v
+    return ret_entry
 
 
 def get_authorized_usernames(url, port):


### PR DESCRIPTION
# 詳細

/app1/と/app1/sub1/に異なるアクセス許可が付けられるように単なる前方一致ではなく最長一致を確認するように修正した。

# テスト内容

ほぼ同一のコードで期待挙動を確認済み。

# チェックリスト

- [x] 自身でコードレビューを実施済みであること
- [ ] 特に理解が困難な箇所について、適切なコメントを記述してあること
- [ ] コードの静的検証を実行し、摘出したエラーを全て対処してあること
- [ ] 必要なドキュメント修正が完了してあること
- [x] 変更によって新たな警告が生じていないこと
